### PR TITLE
fix: use default values for vim.opt

### DIFF
--- a/lua/neodev/build/options.lua
+++ b/lua/neodev/build/options.lua
@@ -79,7 +79,7 @@ function M.build()
     str = str .. ("--- @operator add: vim.opt.%s\n"):format(name)
     str = str .. ("--- @operator sub: vim.opt.%s\n"):format(name)
     str = str .. ("--- @operator pow: vim.opt.%s\n"):format(name)
-    str = str .. ("vim.opt.%s = {}\n"):format(name)
+    str = str .. ("vim.opt.%s = %s\n"):format(name, vim.inspect(option.default))
     if option.shortname ~= "" then
       str = str .. ("vim.opt.%s = vim.opt.%s\n"):format(option.shortname, name)
     end


### PR DESCRIPTION
I'm not sure if this will break anything :sweat_smile:

Here's a comparison of what it does

```diff
diff --git a/types/nightly/options.3.lua b/types/nightly/options.3.lua
index 9c1d9ac..1e544a4 100644
--- a/types/nightly/options.3.lua
+++ b/types/nightly/options.3.lua
 -- `'showbreak'`  `'sbr'` 	string	(default "")
 -- 			global or local to window |global-local|
 -- 	String to put at the start of lines that have been wrapped.  Useful
@@ -23,7 +149,7 @@
 --- @operator add: vim.opt.showbreak
 --- @operator sub: vim.opt.showbreak
 --- @operator pow: vim.opt.showbreak
-vim.opt.showbreak = {}
+vim.opt.showbreak = ""
 vim.opt.sbr = vim.opt.showbreak
 --- @return string
 function vim.opt.showbreak:get()end
@@ -44,7 +170,7 @@ function vim.opt.showbreak:get()end
 --- @operator add: vim.opt.showcmd
 --- @operator sub: vim.opt.showcmd
 --- @operator pow: vim.opt.showcmd
-vim.opt.showcmd = {}
+vim.opt.showcmd = true
```

