### PR TITLE
Change alias `buffer` to `number|string` from `number`

### DIFF
--- a/types/nightly/alias.lua
+++ b/types/nightly/alias.lua
@@ -1,7 +1,7 @@
 ---@meta
 
 ---@alias blob number
----@alias buffer number
+---@alias buffer number|string
 ---@alias channel number
 ---@alias float number
 ---@alias job number

--- a/types/stable/alias.lua
+++ b/types/stable/alias.lua
@@ -1,7 +1,7 @@
 ---@meta
 
 ---@alias blob number
----@alias buffer number
+---@alias buffer number|string
 ---@alias channel number
 ---@alias float number
 ---@alias job number


### PR DESCRIPTION
`buffer` type is used for `vim.fn.bufname`, `vim.fn.bufnr` etc. They are also accept string.