### PR TITLE
Add vim itself to globals for stable

### DIFF
--- a/types/stable/vim.lua
+++ b/types/stable/vim.lua
@@ -1,5 +1,7 @@
 ---@meta
 
+vim = {}
+
 vim = require("vim.shared")
 vim = require("vim.uri")
 vim = require("vim.inspect")


### PR DESCRIPTION
It looks like this was added for nightly some time ago, but got missed for stable.