### PR TITLE
fix: provide a class for vim.api

### DIFF
--- a/types/nightly/api.lua
+++ b/types/nightly/api.lua
@@ -1,5 +1,17 @@
 ---@meta
 
+-- This works around a false-error in sumneko where it cannot determine the
+-- type of:
+--
+--  local a = vim.api  -- cannot infer type of a
+--
+-- By defining an explicit class for vim.api we avoid this error.
+
+---@class vim.api
+local api = vim.api
+vim.api = api
+
+
 --- @param buffer buffer
 --- @param first number
 --- @param last number

--- a/types/nightly/luv.lua
+++ b/types/nightly/luv.lua
@@ -1,5 +1,9 @@
 ---@meta
 
+---@class vim.loop
+local luv = vim.loop
+vim.loop = luv
+
 ---@class vim.loop.Timer
 ---@field start fun(timer:vim.loop.Timer, timeout:integer, repeat:integer, callback:fun())
 ---@field stop fun(timer:vim.loop.Timer)

--- a/types/override/api.lua
+++ b/types/override/api.lua
@@ -1,0 +1,10 @@
+-- This works around a false-error in sumneko where it cannot determine the
+-- type of:
+--
+--  local a = vim.api  -- cannot infer type of a
+--
+-- By defining an explicit class for vim.api we avoid this error.
+
+---@class vim.api
+local api = vim.api
+vim.api = api

--- a/types/override/luv.lua
+++ b/types/override/luv.lua
@@ -1,3 +1,7 @@
+---@class vim.loop
+local luv = vim.loop
+vim.loop = luv
+
 ---@class vim.loop.Timer
 ---@field start fun(timer:vim.loop.Timer, timeout:integer, repeat:integer, callback:fun())
 ---@field stop fun(timer:vim.loop.Timer)


### PR DESCRIPTION
This works around a false-error in sumneko where it cannot determine the
type of:

```lua
 local a = vim.api  -- cannot infer type of a
```

By defining an explicit class for vim.api we avoid this error.
