### PR TITLE
remove config detection

### DIFF
--- a/lua/neodev/lsp.lua
+++ b/lua/neodev/lsp.lua
@@ -52,8 +52,6 @@ function M.on_new_config(config, root_dir)
 
   local opts = require("neodev.config").merge()
 
-  opts.library.enabled = util.is_nvim_config()
-
   if not opts.library.enabled and lua_root then
     opts.library.enabled = true
     opts.library.plugins = false


### PR DESCRIPTION
It's not clear why this logic exists, however if currently resets `library.plugins` when using this for plugin development.