### PR TITLE
fix: searchpair & searchpairpos param types

### DIFF
--- a/types/override/vim.fn.lua
+++ b/types/override/vim.fn.lua
@@ -37,4 +37,26 @@ return {
       { type = "string" },
     },
   },
+  ["vim.fn.searchpair"] = {
+    params = {
+      { name = "start", type = "string" },
+      { name = "middle", type = "string", optional = true },
+      { name = "end", type = "string" },
+      { name = "flags", type = "string", optional = true },
+      { name = "skip", type = "string", optional = true },
+      { name = "stopline", type = "number", optional = true },
+      { name = "timeout", type = "number", optional = true },
+    },
+  },
+  ["vim.fn.searchpairpos"] = {
+    params = {
+      { name = "start", type = "string" },
+      { name = "middle", type = "string", optional = true },
+      { name = "end", type = "string" },
+      { name = "flags", type = "string", optional = true },
+      { name = "skip", type = "string", optional = true },
+      { name = "stopline", type = "number", optional = true },
+      { name = "timeout", type = "number", optional = true },
+    },
+  },
 }


### PR DESCRIPTION
The param types can be read off the examples above the function declaration.