### PR TITLE
fix(luals): plugin name detection of symlinked plugins

### DIFF
--- a/lua/neodev/luals.lua
+++ b/lua/neodev/luals.lua
@@ -14,8 +14,9 @@ function M.library(opts)
   local function add(lib, filter)
     ---@diagnostic disable-next-line: param-type-mismatch
     for _, p in ipairs(vim.fn.expand(lib .. "/lua", false, true)) do
+      local plugin_name = vim.fn.fnamemodify(p, ":h:t")
       p = vim.loop.fs_realpath(p)
-      if p and (not filter or filter[vim.fn.fnamemodify(p, ":h:t")]) then
+      if p and (not filter or filter[plugin_name]) then
         if config.options.pathStrict then
           table.insert(ret, p)
         else


### PR DESCRIPTION
Fixes #139.

When plugins on the packpath are symlinks (which is the case when using a NixOS Neovim module), the plugin names may not be properly detected.

This fixes that by using the symlinked path, not the real path, to detect the plugin name.