### PR TITLE
Make `opts` parameter to `vim.api.nvim_buf_create_user_command` required

### DIFF
--- a/types/stable/api.lua
+++ b/types/stable/api.lua
@@ -253,7 +253,7 @@ function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) e
 --- @param buffer buffer
 --- @param name string
 --- @param command object
---- @param opts? table<string, any>
+--- @param opts table<string, any>
 function vim.api.nvim_buf_create_user_command(buffer, name, command, opts) end
 
 -- Removes an |extmark|.


### PR DESCRIPTION
When this parameter is omitted, NeoVim throws an error. It doesn't need to be a populated table, but it can't be nil.