### PR TITLE
fix(type): accept repeatable param for vim.fn.input

### DIFF
--- a/types/nightly/vim.fn.lua
+++ b/types/nightly/vim.fn.lua
@@ -4598,8 +4598,9 @@ function vim.fn.indexof(object, expr, opts) end
 -- Can also be used as a |method|: >
 --   GetPrompt()->input()
 --- @param opts string|table<string, any>
+--- @param ...? string
 --- @return string
-function vim.fn.input(opts) end
+function vim.fn.input(opts, ...) end
 
 -- {textlist} must be a |List| of strings.  This |List| is
 -- displayed, one string per line.  The user will be prompted to


### PR DESCRIPTION
`vim.fn.input` also works as follows

```lua
vim.fn.input("Give me some path to a folder: ", "/path/", "to/a/folder/bin")
```