### PR TITLE
fix: rename `sumneko_lua` -> `lua_ls`

### DIFF
--- a/.neoconf.json
+++ b/.neoconf.json
@@ -13,6 +13,6 @@
     }
   },
   "lspconfig": {
-    "sumneko_lua": {}
+    "lua_ls": {}
   }
 }


### PR DESCRIPTION
I think this was missed in PR [fix: s/sumneko_lua/lua_ls/ (#124)](https://github.com/folke/neodev.nvim/pull/124), but your latest change [here](https://github.com/folke/neodev.nvim/commit/f06c11344f76fadf2cd497b9490125dfc02946cb#diff-a9f157c1d37a4e8e4a3ff0879b0fb69a04a98c40304c596f476aa00de990b768R16) makes me unsure as it seems intentionally unchanged?

* [LSP name change PR](https://github.com/neovim/nvim-lspconfig/pull/2439)
* Related [neoconf.nvim PR](https://github.com/folke/neoconf.nvim/pull/12)